### PR TITLE
Add libc6-compat package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:alpine
 
 COPY . /app
 WORKDIR /app
-RUN apk add --no-cache ruby-dev build-base curl
+RUN apk add --no-cache ruby-dev build-base curl libc6-compat
 RUN gem install -N rack rackup typhoeus nokogiri webrick
 CMD ["rackup", "-o", "0.0.0.0"]
 


### PR DESCRIPTION
```
/usr/local/bundle/gems/nokogiri-1.15.2-aarch64-linux/lib/nokogiri/extension.rb:7:in `require_relative': Error loading shared library ld-linux-aarch64.so.1: No such file or directory (needed by /usr/local/bundle/gems/nokogiri-1.15.2-aarch64-linux/lib/nokogiri/3.2/nokogiri.so) - /usr/local/bundle/gems/nokogiri-1.15.2-aarch64-linux/lib/nokogiri/3.2/nokogiri.so (LoadError)
```